### PR TITLE
Feedback

### DIFF
--- a/feedback/topdown-promille-def.R
+++ b/feedback/topdown-promille-def.R
@@ -1,0 +1,105 @@
+## hier aus didaktischen Gründen teilweise englische und deutsche Kommentare gemischt.
+## sie sollten englische Kommentare schreiben (in diesem Kurs & wann immer sie
+## vorhaben anderen Ihren Code zugänglich zu machen.)
+
+# computes approximate BAC (in per mille) at the end of the party (drinking_time[2])
+#
+# method:
+# https://web.archive.org/web/20150123143123/http://promille-rechner.org/erlaeuterung-der-promille-berechnung/
+# massn: 1l@6%; hoibe: 0.5l@6%; wein: 0.2l@11%; schnaps: 0.04l@40%
+#
+# inputs:
+#   age in years
+#   height in cm
+#   weight in kg
+#   drinking_time: sorted POSIXct vector giving start and end of the party
+#   drinks: list or vector with names "massn", "hoibe", "wein", "schnaps"
+#     counting the number consumed of each type of drink
+#  output:
+#    approximate BAC in per mille
+tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight,
+                              drinking_time, drinks) {
+  # inputs homogen machen:
+  drinks <- unlist(drinks)
+  sex <- tolower(sex)
+  # inputs checken:
+  checkmate::assert_number(age,
+                           lower = 10, upper = 110)
+  sex <- match.arg(sex)
+  checkmate::assert_number(height,
+                           lower = 100, upper = 230)
+  checkmate::assert_number(weight,
+                           lower = 40, upper = 300)
+  checkmate::assert_subset(names(drinks),
+                           choices = c("massn", "hoibe", "wein", "schnaps"),
+                           empty.ok = FALSE)
+  checkmate::assert_numeric(drinks,
+                            lower = 0, any.missing = FALSE, min.len = 1)
+  checkmate::assert_posixct(drinking_time,
+                            any.missing = FALSE, sorted = TRUE, len = 2)
+
+  # isTRUE weil drinks["schnaps"] NA ist wenn kein "schnaps"-Eintrag da ist.
+  illegal <- (age < 16 & sum(drinks) > 0) |
+             (age < 18 & isTRUE(drinks["schnaps"] > 0))
+  if (illegal) {
+    warning("\u2639 ...illegal!  \u2639")
+  }
+
+  alcohol_drunk <- get_alcohol(drinks)
+  bodywater <- get_bodywater(sex, age, height, weight)
+  max_permille <- get_permille(alcohol_drunk, bodywater)
+  sober_up(max_permille, drinking_time)
+}
+
+# compute consumed alcohol in g
+# massn, hoibe: 6%; wein: .2l@11%; schnaps: 4cl@40%
+get_alcohol <- function(drinks) {
+  # in ml
+  volume <- c(
+    "massn" = 1000,
+    "hoibe" = 500,
+    "wein" = 200,
+    "schnaps" = 40
+  )
+  # in volume-%
+  alcohol_concentration <- c(
+    "massn" = 0.06,
+    "hoibe" = 0.06,
+    "wein" = 0.11,
+    "schnaps" = 0.4
+  )
+  alcohol_density <- 0.8
+
+  # die indizierung mit names(drinks) erzeugt vektoren von volumen
+  # und alkoholgehalt die zu den einträgen in drinks passen
+  # (richtige reihenfolge & laenge):
+  sum(drinks * volume[names(drinks)] *
+        alcohol_concentration[names(drinks)] * alcohol_density)
+}
+
+# compute amount of water in a human body
+# coefficients from web-site promillerechner.org linked above
+get_bodywater <- function(sex = c("male", "female"), age, height, weight) {
+  coefficients <- switch(sex,
+                         "male"   = c(2.447, -0.09516, 0.1074, 0.3362),
+                         "female" = c(0.203, -0.07, 0.1069, 0.2466))
+ t(coefficients) %*% c(1, age, height, weight)
+}
+
+# compute max BAC (assumed: at drinking_time[1]...)
+get_permille <- function(alcohol_drunk, bodywater) {
+  alcohol_density <- 0.8
+  blood_density <- 1.055
+  permille <- alcohol_density * alcohol_drunk / (blood_density * bodywater)
+  permille
+}
+
+# compute BAC at drinking_time[2]
+sober_up <- function(permille, drinking_time) {
+  partylength <- difftime(drinking_time[2], drinking_time[1], units = "hours")
+  sober_per_hour <- 0.15
+  # abbau beginnt erst nach einer stunde:
+  depletion_duration <- max(0, partylength - 1)
+  # abbau kann nicht zu negativen promille führen:
+  max(0, permille - depletion_duration * sober_per_hour)
+}

--- a/feedback/topdown-promille-sol.Rmd
+++ b/feedback/topdown-promille-sol.Rmd
@@ -1,0 +1,12 @@
+```{r, child = "topdown-promille-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+Zum Beispiel so:
+```{r, def_promillerechner, code = readLines("topdown-promille-def.R"), echo=TRUE}
+```
+
+Die Fehlermeldungen könnte man hier sicher noch etwas informativer und allgemeinverständlicher machen indem man statt `checkmate::assert_XY` jeweils `if(<argument ungeeignet>) stop("<allgemeinverständliche Fehlermeldung>")` benutzt.  


### PR DESCRIPTION
@Liesele 

Ok, das war eher nix, insgesamt gesehen, ABER den wichtigen Teil zu top down design / definition von unterfunktionen haben sie gut gelöst. Der Rest ist eher Übungssache, bleiben Sie dran und lassen Sie sich nicht entmutigen. Rückfragen zur Korrektur gerne direkt hier drunter im Chat oder halt per zoom nächste Woche.... 

----------------------------------------------------------------------

:+1: :

- Sie haben das Prinzip von der Kapselung in Unterfunktionen verstanden und einen anständigen Versuch unternommen das hier umzusetzen  - super!
- Sinnvolles "defensive programming"  mit weitestgehend adäquaten input checks, schön!
- konsistente und gut überlegte aussagekräftige benamung, weiter so!

:-1: :

-  Ihre Lösung ist mir zu schlampig formatiert und aufbereitet -- bitte in Zukunft `checklist` benutzen (s.u. für den Output) und **gefälligst aufräumen** vorm abgeben :point_up: 

- Ihre Lösung erfüllt fast keine der funktionalen Anforderungen die durch das Testfile definiert sind - 8 von 10 tests versagen:
```r
> testthat::test_file("ex/topdown/topdown-promille-tests.R")

══ Testing topdown-promille-tests.R ════════════════════════════════════════════════════════════════════════════════════════
[ FAIL 8 | WARN 0 | SKIP 0 | PASS 2 ]

── Failure (topdown-promille-tests.R:6:3): basic implementation is correct ─────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 2.359.
Types not compatible: character is not double

── Failure (topdown-promille-tests.R:16:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.4.
Types not compatible: character is not double

── Failure (topdown-promille-tests.R:26:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.687.
Types not compatible: character is not double

── Failure (topdown-promille-tests.R:36:3): basic implementation is correct ────────────────────────────────────────────────
tell_me_how_drunk(...) not equivalent to 0.
Types not compatible: character is not double

── Error (topdown-promille-tests.R:67:3): interface for sex is implemented flexibly ────────────────────────────────────────
Error: sex must be 'male' or 'female'
Backtrace:
 1. testthat::expect_equal(...) topdown-promille-tests.R:67:2
 4. global::tell_me_how_drunk(...)

── Error (topdown-promille-tests.R:87:3): interface for drinks is implemented flexibly ─────────────────────────────────────
Error: sex must be 'male' or 'female'
Backtrace:
 1. testthat::expect_equal(...) topdown-promille-tests.R:87:2
 4. global::tell_me_how_drunk(...)

── Failure (topdown-promille-tests.R:126:3): legal drinking age is checked ─────────────────────────────────────────────────
`tell_me_how_drunk(...)` did not produce any warnings.

── Failure (topdown-promille-tests.R:136:3): legal drinking age is checked ─────────────────────────────────────────────────
`tell_me_how_drunk(...)` did not produce any warnings.

[ FAIL 8 | WARN 0 | SKIP 0 | PASS 2 ]
```
formal weil sie einen string zurückgeben statt die promillezahl als ZAHL (...why? :roll_eyes:), aber auch die berechnete Zahl die hier falsch formatiert zurückgegeben wird ist nie korrekt (s. BUGs weiter unten). Das ist natürlich ein Desaster, tbh. Sie müssen schon überprüfen ob der Code, den sie so zusammenschreiben, auch irgendwie was sinnvolles tut, wenn ich ihnen schon so nett lauter Testcases mitliefere...  :point_left: 

--------------------------------------------------------------------------------------------------------------------------------------------------

Details:

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L50-L53
Codestruktur:  Formeln basieren auf ml, sie benutzen hier liter um das dann später in calc_blood_alc: https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L76 wieder durch 1000 zu teilen. dort ist aber nicht dokumentiert woher dieses mysteriöse `*1000` kommt. Lesbarer wäre es also das halt hier gleich in der richtigen Einheit auszurechnen.  
Stilistisch: ziemlich häßlich da mit zigmal `try` auf evtl nichtexistente elemente zuzugreifen -- vgl Musterlösung für robustere und weniger brutale Lösung.

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L66
BUG: hier muss ein `return` hin, sonst geben sie auch für männer immer das ergebnis der formeln für frauen zurück das in l. 69 berechnet wird.... :face_with_head_bandage: 

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L85
BUG: falls  `drinking_time_diff < 1` tut das nichts sinnvolles  hier (abbau geht erst nach einer stunde los, vgl Musterlösung)

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L106-L112 KIS -- benutze jeweils `assert_number` mit entsprechenden Zusatzargumenten, vgl Musterlösung, statt handgestrickten checks und doppeltgemoppelten checks.

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L107-L108
**nicht** teil der spezifikation, bitte verkneifen. außerdem bitte gescheit formatieren und korrekt einrücken.

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L114 reicht nicht -- vgl Musterlösung -- `assert_posixct` + zusatzargumente

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L116-L118 bitte sowas in zukunft immer mit `match.arg`-- das macht input checks und input homogenization für character argumente in einem Aufwasch.... vgl Musterlösung

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L124
naja, das zu ermöglichen war genau teil der aufgabe, s. Testfile :disappointed: 

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L127 idiomatischer mit `%in%`, vgl Musterlösung 

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L132 nee, bitte nicht: `assert(check_BLA(x))` ist das selbe wie `assert_BLA(x)`  -- KIS!

- https://github.com/fort-w2021/promille-ex-Liesele/blob/1a49a93053886e6167ff9bfb98165eeaf139c604/topdown-promille-sol.R#L149 nicht nach spezifikation, sie hätten einfach `blood_alc_stop` retournieren sollen....
-------------------------------------------------------------------------------------------------------------------------------------------------

```
> checklist::checklist("~/Downloads/topdown-promille-sol.R")
Starting checks.
Checking file extensions.

#---------------------------------------------------------------#
Running linters:
/home/fabians/Downloads/topdown-promille-sol.R:20:3: style: Commented code should be removed.
# list("massn" = 2, "schnaps" = 3)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:21:3: style: Commented code should be removed.
# c("wein" = 4, "hoibe" = 1)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:24:3: style: Commented code should be removed.
# rho <- 0.8 # Alkoholdichte
  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:25:3: style: Commented code should be removed.
# rho_blut <- 1.055 # g/cm^3
  ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:26:3: style: Commented code should be removed.
# h <- height
  ^~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:27:3: style: Commented code should be removed.
# m <- weight
  ^~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:28:3: style: Commented code should be removed.
# t <- age
  ^~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:29:3: style: Commented code should be removed.
# V <- drinks$menge # Volumen
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:30:3: style: Commented code should be removed.
# e <- drinks$umdrehungen # Alkgehalt
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:32:3: style: Commented code should be removed.
# A <- V * e * rho  # Masse Alkohol berechnen
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:34:3: style: Commented code should be removed.
# gkw_mann <- 2.447 - 0.09516 * t + 0.1074 * h + 0.3362 * m
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:35:3: style: Commented code should be removed.
# gkw_frau <-  0.203 - 0.07 * t + 0.1069 * h + 0.2466 * m
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:37:3: style: Commented code should be removed.
# c <- 0.8 * A / (rho_blut * gkw)  # Blutalkohol berechnen
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:39:3: style: Commented code should be removed.
# c_final <- c - ((drinking_time - 1) * 0.15)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:46:31: style: Remove spaces before the left parenthesis in a function call.
calc_mass_alcohol <- function (drinks) {
                              ^
/home/fabians/Downloads/topdown-promille-sol.R:50:7: style: Remove spaces before the left parenthesis in a function call.
  try (drinks$wein <- drinks$wein * 0.2 * 0.11, silent = T)
      ^
/home/fabians/Downloads/topdown-promille-sol.R:50:14: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$wein <- drinks$wein * 0.2 * 0.11, silent = T)
             ^
/home/fabians/Downloads/topdown-promille-sol.R:50:29: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$wein <- drinks$wein * 0.2 * 0.11, silent = T)
                            ^
/home/fabians/Downloads/topdown-promille-sol.R:50:59: style: Use TRUE instead of the symbol T.
  try (drinks$wein <- drinks$wein * 0.2 * 0.11, silent = T)
                                                         ~^
/home/fabians/Downloads/topdown-promille-sol.R:50:59: style: Use TRUE instead of the symbol T.
  try (drinks$wein <- drinks$wein * 0.2 * 0.11, silent = T)
                                                         ~^
/home/fabians/Downloads/topdown-promille-sol.R:51:7: style: Remove spaces before the left parenthesis in a function call.
  try (drinks$massn <- drinks$massn * 1 * 0.06, silent = T)
      ^
/home/fabians/Downloads/topdown-promille-sol.R:51:14: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$massn <- drinks$massn * 1 * 0.06, silent = T)
             ^
/home/fabians/Downloads/topdown-promille-sol.R:51:30: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$massn <- drinks$massn * 1 * 0.06, silent = T)
                             ^
/home/fabians/Downloads/topdown-promille-sol.R:51:59: style: Use TRUE instead of the symbol T.
  try (drinks$massn <- drinks$massn * 1 * 0.06, silent = T)
                                                         ~^
/home/fabians/Downloads/topdown-promille-sol.R:51:59: style: Use TRUE instead of the symbol T.
  try (drinks$massn <- drinks$massn * 1 * 0.06, silent = T)
                                                         ~^
/home/fabians/Downloads/topdown-promille-sol.R:52:7: style: Remove spaces before the left parenthesis in a function call.
  try (drinks$hoibe <- drinks$hoibe * 0.5 * 0.06, silent = T)
      ^
/home/fabians/Downloads/topdown-promille-sol.R:52:14: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$hoibe <- drinks$hoibe * 0.5 * 0.06, silent = T)
             ^
/home/fabians/Downloads/topdown-promille-sol.R:52:30: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$hoibe <- drinks$hoibe * 0.5 * 0.06, silent = T)
                             ^
/home/fabians/Downloads/topdown-promille-sol.R:52:61: style: Use TRUE instead of the symbol T.
  try (drinks$hoibe <- drinks$hoibe * 0.5 * 0.06, silent = T)
                                                           ~^
/home/fabians/Downloads/topdown-promille-sol.R:52:61: style: Use TRUE instead of the symbol T.
  try (drinks$hoibe <- drinks$hoibe * 0.5 * 0.06, silent = T)
                                                           ~^
/home/fabians/Downloads/topdown-promille-sol.R:53:7: style: Remove spaces before the left parenthesis in a function call.
  try (drinks$schnaps <- drinks$schnaps * 0.04 * 0.40, silent = T)
      ^
/home/fabians/Downloads/topdown-promille-sol.R:53:14: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$schnaps <- drinks$schnaps * 0.04 * 0.40, silent = T)
             ^
/home/fabians/Downloads/topdown-promille-sol.R:53:32: warning: Use `[[` instead of `$`  to extract an element.
  try (drinks$schnaps <- drinks$schnaps * 0.04 * 0.40, silent = T)
                               ^
/home/fabians/Downloads/topdown-promille-sol.R:53:66: style: Use TRUE instead of the symbol T.
  try (drinks$schnaps <- drinks$schnaps * 0.04 * 0.40, silent = T)
                                                                ~^
/home/fabians/Downloads/topdown-promille-sol.R:53:66: style: Use TRUE instead of the symbol T.
  try (drinks$schnaps <- drinks$schnaps * 0.04 * 0.40, silent = T)
                                                                ~^
/home/fabians/Downloads/topdown-promille-sol.R:55:25: style: Remove spaces before the left parenthesis in a function call.
  total_mass_alc <- sum (drinks)
                        ^
/home/fabians/Downloads/topdown-promille-sol.R:56:10: style: Remove spaces before the left parenthesis in a function call.
  return (total_mass_alc)
         ^
/home/fabians/Downloads/topdown-promille-sol.R:64:1: style: Functions need comments defining their purpose, arguments & returns.
calc_total_body_water <- function (age, sex, height, weight) {
^
/home/fabians/Downloads/topdown-promille-sol.R:64:35: style: Remove spaces before the left parenthesis in a function call.
calc_total_body_water <- function (age, sex, height, weight) {
                                  ^
/home/fabians/Downloads/topdown-promille-sol.R:66:1: style: Lines should not be more than 80 characters.
    total_body_water <- 2.447 - 0.09516 * age + 0.1074 * height + 0.3362 * weight
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:70:10: style: Remove spaces before the left parenthesis in a function call.
  return (total_body_water)
         ^
/home/fabians/Downloads/topdown-promille-sol.R:75:28: style: Remove spaces before the left parenthesis in a function call.
calc_blood_alc <- function (total_mass_alc, total_body_water) {
                           ^
/home/fabians/Downloads/topdown-promille-sol.R:76:69: style: Put spaces around all infix operators.
  blood_alc <-  (0.8 *  total_mass_alc / (1.055 * total_body_water))*1000
                                                                   ~^~
/home/fabians/Downloads/topdown-promille-sol.R:77:10: style: Remove spaces before the left parenthesis in a function call.
  return (blood_alc)
         ^
/home/fabians/Downloads/topdown-promille-sol.R:82:38: style: Remove spaces before the left parenthesis in a function call.
calc_blood_alc_stop_time <- function (blood_alc, drinking_time) {
                                     ^
/home/fabians/Downloads/topdown-promille-sol.R:83:36: style: Remove spaces before the left parenthesis in a function call.
  drinking_time_diff <- as.numeric (abs(drinking_time [2] - drinking_time [1]))
                                   ^
/home/fabians/Downloads/topdown-promille-sol.R:83:55: warning: Use `[[` instead of `[`  to extract an element.
  drinking_time_diff <- as.numeric (abs(drinking_time [2] - drinking_time [1]))
                                                      ^
/home/fabians/Downloads/topdown-promille-sol.R:83:75: warning: Use `[[` instead of `[`  to extract an element.
  drinking_time_diff <- as.numeric (abs(drinking_time [2] - drinking_time [1]))
                                                                          ^
/home/fabians/Downloads/topdown-promille-sol.R:87:25: style: Remove spaces before the left parenthesis in a function call.
  blood_alc_stop <- max (blood_alc_stop_theory, 0)
                        ^
/home/fabians/Downloads/topdown-promille-sol.R:88:10: style: Remove spaces before the left parenthesis in a function call.
  return (blood_alc_stop)
         ^
/home/fabians/Downloads/topdown-promille-sol.R:94:1: style: functions should have cyclomatic complexity of less than 10, this has 11.
tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight, 
^
/home/fabians/Downloads/topdown-promille-sol.R:94:1: style: Functions need comments defining their purpose, arguments & returns.
tell_me_how_drunk <- function(age, sex = c("male", "female"), height, weight, 
^
/home/fabians/Downloads/topdown-promille-sol.R:98:49: style: Commas should never have a space before.
  possible_drinks <- c("massn", "hoibe", "wein" ,"schnaps")
                                               ~^
/home/fabians/Downloads/topdown-promille-sol.R:98:50: style: Commas should always have a space after.
  possible_drinks <- c("massn", "hoibe", "wein" ,"schnaps")
                                                 ^
/home/fabians/Downloads/topdown-promille-sol.R:101:21: style: Remove spaces before the left parenthesis in a function call.
  drinks <- as.list (drinks)
                    ^
/home/fabians/Downloads/topdown-promille-sol.R:107:13: style: Remove spaces before the left parenthesis in a function call.
  if (is.na (age) || age < 14) stop (
            ^
/home/fabians/Downloads/topdown-promille-sol.R:107:37: style: Remove spaces before the left parenthesis in a function call.
  if (is.na (age) || age < 14) stop (
                                    ^
/home/fabians/Downloads/topdown-promille-sol.R:110:10: style: Remove spaces before the left parenthesis in a function call.
  assert (check_numeric(height), height > 0, height < Inf, combine = "and")
         ^
/home/fabians/Downloads/topdown-promille-sol.R:112:10: style: Remove spaces before the left parenthesis in a function call.
  assert (check_numeric(weight))
         ^
/home/fabians/Downloads/topdown-promille-sol.R:114:1: style: Lines should not be more than 80 characters.
  assert_true (class(drinking_time) == "POSIXct" || class(drinking_time) == "POSIXt" )
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:114:15: style: Remove spaces before the left parenthesis in a function call.
  assert_true (class(drinking_time) == "POSIXct" || class(drinking_time) == "POSIXt" )
              ^
/home/fabians/Downloads/topdown-promille-sol.R:114:85: style: Do not place spaces around code in parentheses or square brackets.
  assert_true (class(drinking_time) == "POSIXct" || class(drinking_time) == "POSIXt" )
                                                                                    ^
/home/fabians/Downloads/topdown-promille-sol.R:118:45: style: Remove spaces before the left parenthesis in a function call.
  if (sex != "female" & sex != "male") stop ("sex must be 'male' or 'female'")
                                            ^
/home/fabians/Downloads/topdown-promille-sol.R:120:15: style: Remove spaces before the left parenthesis in a function call.
  if (is.null (names (drinks))) stop ("you must report WHAT you drink, not just
              ^
/home/fabians/Downloads/topdown-promille-sol.R:120:22: style: Remove spaces before the left parenthesis in a function call.
  if (is.null (names (drinks))) stop ("you must report WHAT you drink, not just
                     ^
/home/fabians/Downloads/topdown-promille-sol.R:120:38: style: Remove spaces before the left parenthesis in a function call.
  if (is.null (names (drinks))) stop ("you must report WHAT you drink, not just
                                     ^
/home/fabians/Downloads/topdown-promille-sol.R:124:1: style: Lines should not be more than 80 characters.
  if (sum(duplicated (names(drinks))) > 0) stop ("please list drinks only once!") 
^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/fabians/Downloads/topdown-promille-sol.R:124:22: style: Remove spaces before the left parenthesis in a function call.
  if (sum(duplicated (names(drinks))) > 0) stop ("please list drinks only once!") 
                     ^
/home/fabians/Downloads/topdown-promille-sol.R:124:49: style: Remove spaces before the left parenthesis in a function call.
  if (sum(duplicated (names(drinks))) > 0) stop ("please list drinks only once!") 
                                                ^
/home/fabians/Downloads/topdown-promille-sol.R:127:18: style: Remove spaces before the left parenthesis in a function call.
  if (is.element (FALSE, is.element(names (drinks),possible_drinks))) stop (
                 ^
/home/fabians/Downloads/topdown-promille-sol.R:127:43: style: Remove spaces before the left parenthesis in a function call.
  if (is.element (FALSE, is.element(names (drinks),possible_drinks))) stop (
                                          ^
/home/fabians/Downloads/topdown-promille-sol.R:127:52: style: Commas should always have a space after.
  if (is.element (FALSE, is.element(names (drinks),possible_drinks))) stop (
                                                   ^
/home/fabians/Downloads/topdown-promille-sol.R:127:76: style: Remove spaces before the left parenthesis in a function call.
  if (is.element (FALSE, is.element(names (drinks),possible_drinks))) stop (
                                                                           ^
/home/fabians/Downloads/topdown-promille-sol.R:132:10: style: Remove spaces before the left parenthesis in a function call.
  assert (check_numeric (unlist(drinks)))
         ^
/home/fabians/Downloads/topdown-promille-sol.R:132:25: style: Remove spaces before the left parenthesis in a function call.
  assert (check_numeric (unlist(drinks)))
                        ^
/home/fabians/Downloads/topdown-promille-sol.R:135:31: style: Remove spaces before the left parenthesis in a function call.
  drinking_time <- as.POSIXct (drinking_time)
                              ^
/home/fabians/Downloads/topdown-promille-sol.R:141:45: style: Remove spaces before the left parenthesis in a function call.
  total_body_water <- calc_total_body_water (age, sex, height, weight)
                                            ^
/home/fabians/Downloads/topdown-promille-sol.R:144:31: style: Remove spaces before the left parenthesis in a function call.
  blood_alc <- calc_blood_alc (total_mass_alc, total_body_water)
                              ^
/home/fabians/Downloads/topdown-promille-sol.R:147:46: style: Remove spaces before the left parenthesis in a function call.
  blood_alc_stop <- calc_blood_alc_stop_time (blood_alc, drinking_time)
                                             ^
/home/fabians/Downloads/topdown-promille-sol.R:149:10: style: Remove spaces before the left parenthesis in a function call.
  return (paste ("Ihr Blutalkohol beträgt", round (blood_alc_stop, digits = 2),
         ^
/home/fabians/Downloads/topdown-promille-sol.R:149:17: style: Remove spaces before the left parenthesis in a function call.
  return (paste ("Ihr Blutalkohol beträgt", round (blood_alc_stop, digits = 2),
                ^
/home/fabians/Downloads/topdown-promille-sol.R:149:51: style: Remove spaces before the left parenthesis in a function call.
  return (paste ("Ihr Blutalkohol beträgt", round (blood_alc_stop, digits = 2),
                                                  ^
#---------------------------------------------------------------#
Checking usage in file <topdown-promille-sol.R>:

calc_mass_alcohol: local variable ‘density_alc’ assigned but may not be used (~/Downloads/topdown-promille-sol.R:48)
calc_mass_alcohol: parameter ‘drinks’ changed by assignment (~/Downloads/topdown-promille-sol.R:47)
tell_me_how_drunk: no visible global function definition for ‘assert’ (~/Downloads/topdown-promille-sol.R:106)
tell_me_how_drunk: no visible global function definition for ‘check_integer’ (~/Downloads/topdown-promille-sol.R:106)
tell_me_how_drunk: no visible global function definition for ‘check_count’ (~/Downloads/topdown-promille-sol.R:106)
tell_me_how_drunk: no visible global function definition for ‘assert’ (~/Downloads/topdown-promille-sol.R:110)
tell_me_how_drunk: no visible global function definition for ‘check_numeric’ (~/Downloads/topdown-promille-sol.R:110)
tell_me_how_drunk: no visible global function definition for ‘assert’ (~/Downloads/topdown-promille-sol.R:112)
tell_me_how_drunk: no visible global function definition for ‘check_numeric’ (~/Downloads/topdown-promille-sol.R:112)
tell_me_how_drunk: no visible global function definition for ‘assert_true’ (~/Downloads/topdown-promille-sol.R:114)
tell_me_how_drunk: no visible global function definition for ‘assert’ (~/Downloads/topdown-promille-sol.R:132)
tell_me_how_drunk: no visible global function definition for ‘check_numeric’ (~/Downloads/topdown-promille-sol.R:132)
tell_me_how_drunk: parameter ‘drinking_time’ changed by assignment (~/Downloads/topdown-promille-sol.R:114)
tell_me_how_drunk: parameter ‘drinks’ changed by assignment (~/Downloads/topdown-promille-sol.R:101)
tell_me_how_drunk: parameter ‘sex’ changed by assignment (~/Downloads/topdown-promille-sol.R:116)